### PR TITLE
fix(README): update github repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To remove all resources created by this example, do the following:
 First clone the repo:
 ```
 # Clone it from github
-git clone https://github.com/awslabs/serverless-stepfunctions-ebs-snapshots.git
+git clone https://github.com/aws-samples/aws-step-functions-ebs-snapshot-mgmt.git
 ```
 
 Make the edits you want to make. For instance, if you want to modify the DR region (i.e. not use Ohio), then in the PrimaryRegionTemplate.yaml file, edit the default value for the DRRegion parameter to the region you would prefer to use:


### PR DESCRIPTION
Previous URL is no longer valid:
```
$ git clone https://github.com/awslabs/serverless-stepfunctions-ebs-snapshots.git
Cloning into 'serverless-stepfunctions-ebs-snapshots'...
remote: Repository not found.
fatal: repository 'https://github.com/awslabs/serverless-stepfunctions-ebs-snapshots.git/' not found
```