### PR TITLE
Update nodejs runtime to supported version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*Packaged.yaml

--- a/DR_RegionTemplate.yaml
+++ b/DR_RegionTemplate.yaml
@@ -177,7 +177,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: TagSnapshotCopy.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "TagSnapshotCopy-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -189,7 +189,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CountSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "CountSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -201,7 +201,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: DeleteOldSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "DeleteOldSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotDeletionIAMRole.Arn
@@ -216,7 +216,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: Notification.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "Notification-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SNSNotificationIAMRole.Arn

--- a/DR_RegionTemplate.yaml
+++ b/DR_RegionTemplate.yaml
@@ -10,6 +10,10 @@ Parameters:
     Description: 'Suffix to append to the Lambda functions.'
     Type: 'String'
     Default: 'ebs-snapshot-mgmt-dr'
+  NodeVersion:
+    Description: 'Node Runtime version.'
+    Type: 'String'
+    Default: 'nodejs10.x'
 Resources:
   StatesExecutionRole:
     Type: "AWS::IAM::Role"
@@ -177,7 +181,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: TagSnapshotCopy.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "TagSnapshotCopy-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -189,7 +193,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CountSnapshots.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "CountSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -201,7 +205,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: DeleteOldSnapshots.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "DeleteOldSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotDeletionIAMRole.Arn
@@ -216,7 +220,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: Notification.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "Notification-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SNSNotificationIAMRole.Arn

--- a/DR_RegionTemplate.yaml
+++ b/DR_RegionTemplate.yaml
@@ -5,11 +5,11 @@ Parameters:
   Retention:
     Description: 'The number of snapshots you want to keep per volume in your DR Region.'
     Type: 'String'
-    Default: '1'
+    Default: '30'
   FunctionNameSuffix:
     Description: 'Suffix to append to the Lambda functions.'
     Type: 'String'
-    Default: ''
+    Default: 'ebs-snapshot-mgmt-dr'
 Resources:
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/PrimaryRegionTemplate.yaml
+++ b/PrimaryRegionTemplate.yaml
@@ -18,6 +18,10 @@ Parameters:
     Description: 'Suffix to append to the Lambda functions.'
     Type: 'String'
     Default: 'ebs-snapshot-mgmt-dr'
+  NodeVersion:
+    Description: 'Node Runtime version.'
+    Type: 'String'
+    Default: 'nodejs10.x'
 Resources:
   StatesExecutionRole:
     Type: "AWS::IAM::Role"
@@ -186,7 +190,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: TagSnapshots.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "TagSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -201,7 +205,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CountSnapshots.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "CountSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -216,7 +220,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CopySnapshotToDR.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "CopySnapshotToDRRegion-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -231,7 +235,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: DeleteOldSnapshots.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "DeleteOldSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotDeletionIAMRole.Arn
@@ -246,7 +250,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: Notification.handler
-      Runtime: nodejs8.10
+      Runtime: !Ref NodeVersion
       FunctionName: !Sub "Notification-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SNSNotificationIAMRole.Arn

--- a/PrimaryRegionTemplate.yaml
+++ b/PrimaryRegionTemplate.yaml
@@ -5,19 +5,19 @@ Parameters:
   tagKeyValue:
     Description: 'The value for the key tag that you want all volumes to have for the snapshot managment to apply.'
     Type: 'String'
-    Default: 'none'
+    Default: 'SnapshotCreatorDLM'
   DRRegion:
     Description: 'The DR region where snapshots will be copied (This should be a different region from the region you are running this CloudFormation stack in.'
     Type: 'String'
-    Default: 'us-east-2'
+    Default: 'eu-west-2'
   Retention:
     Description: 'The number of snapshots you want to keep per volume.'
     Type: 'String'
-    Default: '7'
+    Default: '30'
   FunctionNameSuffix:
     Description: 'Suffix to append to the Lambda functions.'
     Type: 'String'
-    Default: ''
+    Default: 'ebs-snapshot-mgmt-dr'
 Resources:
   StatesExecutionRole:
     Type: "AWS::IAM::Role"

--- a/PrimaryRegionTemplate.yaml
+++ b/PrimaryRegionTemplate.yaml
@@ -186,7 +186,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: TagSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "TagSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -201,7 +201,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CountSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "CountSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -216,7 +216,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CopySnapshotToDR.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "CopySnapshotToDRRegion-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -231,7 +231,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: DeleteOldSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "DeleteOldSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotDeletionIAMRole.Arn
@@ -246,7 +246,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: Notification.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       FunctionName: !Sub "Notification-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SNSNotificationIAMRole.Arn

--- a/PrimaryRegionTemplate.yaml
+++ b/PrimaryRegionTemplate.yaml
@@ -5,11 +5,11 @@ Parameters:
   tagKeyValue:
     Description: 'The value for the key tag that you want all volumes to have for the snapshot managment to apply.'
     Type: 'String'
-    Default: 'SnapshotCreatorDLM'
+    Default: 'CopySnapshotsToDRRegion'
   DRRegion:
     Description: 'The DR region where snapshots will be copied (This should be a different region from the region you are running this CloudFormation stack in.'
     Type: 'String'
-    Default: 'eu-west-2'
+    Default: 'us-west-2'
   Retention:
     Description: 'The number of snapshots you want to keep per volume.'
     Type: 'String'


### PR DESCRIPTION
Lambda no longer supports nodejs 4.3. Update the default nodejs runtime in the cloudformation templates.