### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/DR_RegionTemplate.yaml
+++ b/DR_RegionTemplate.yaml
@@ -177,7 +177,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: TagSnapshotCopy.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "TagSnapshotCopy-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -189,7 +189,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CountSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "CountSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -201,7 +201,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: DeleteOldSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "DeleteOldSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotDeletionIAMRole.Arn
@@ -216,7 +216,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: Notification.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "Notification-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SNSNotificationIAMRole.Arn

--- a/PrimaryRegionTemplate.yaml
+++ b/PrimaryRegionTemplate.yaml
@@ -186,7 +186,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: TagSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "TagSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -201,7 +201,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CountSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "CountSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -216,7 +216,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: CopySnapshotToDR.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "CopySnapshotToDRRegion-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotManagementIAMRole.Arn
@@ -231,7 +231,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: DeleteOldSnapshots.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "DeleteOldSnapshots-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SnapshotDeletionIAMRole.Arn
@@ -246,7 +246,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: Notification.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       FunctionName: !Sub "Notification-${FunctionNameSuffix}"
       CodeUri: .
       Role: !GetAtt SNSNotificationIAMRole.Arn


### PR DESCRIPTION
CloudFormation templates in aws-step-functions-ebs-snapshot-mgmt have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.